### PR TITLE
Handle multiple currencies

### DIFF
--- a/dapper-invoice.cls
+++ b/dapper-invoice.cls
@@ -4,6 +4,25 @@
 \NeedsTeXFormat{LaTeX2e}
 \LoadClass[11pt]{article}
 
+% For page number calculations
+\RequirePackage{ifthen}
+
+% To handle key=value options in class definition
+\RequirePackage{kvoptions}
+\SetupKeyvalOptions{%
+    prefix=dapper@
+}
+% Default currency option is "dollar"
+\DeclareStringOption[dollar]{currency}[dollar]
+\ProcessKeyvalOptions*
+
+\RequirePackage{eurosym}
+
+\ifthenelse{\equal{\dapper@currency}{dollar}}{\newcommand{\currencysym}{\$}}{}
+\ifthenelse{\equal{\dapper@currency}{euro}}{\newcommand{\currencysym}{\euro}}{}
+\ifthenelse{\equal{\dapper@currency}{pound}}{\newcommand{\currencysym}{\textsterling}}{}
+
+% Set the standard geometry
 \RequirePackage[hmargin=.75in,vmargin=1in]{geometry}
 
 % For links and metadata
@@ -14,9 +33,6 @@
 
 % For "At*" hooks
 \RequirePackage{etoolbox}
-
-% For page number calculations
-\RequirePackage{ifthen}
 
 % For adjusting footer
 \RequirePackage{fancyhdr}
@@ -206,8 +222,8 @@
     \end{minipage} &
     {\itemizationRowStyle \@formatHoursLeft{#2}} &
     {\itemizationRowStyle \@formatHoursRight{#2}} &
-    {\itemizationRowStyle \$#3} &
-    {\itemizationRowStyle \$\calcamount{#2}{#3}}
+    {\itemizationRowStyle \currencysym#3} &
+    {\itemizationRowStyle \currencysym\calcamount{#2}{#3}}
     \\
     \noalign{\medskip}
 }
@@ -220,8 +236,8 @@
     \end{minipage} &
     {\itemizationRowStyle \@formatHoursLeft{#2}} &
     {\itemizationRowStyle \@formatHoursRight{#2}} &
-    {\itemizationRowStyle \$#3} &
-    {\itemizationRowStyle \$\calcamount{#2}{#3}}
+    {\itemizationRowStyle \currencysym#3} &
+    {\itemizationRowStyle \currencysym\calcamount{#2}{#3}}
     \\
     \noalign{\medskip}
 }

--- a/example.tex
+++ b/example.tex
@@ -1,4 +1,7 @@
 \documentclass[letterpaper]{dapper-invoice}
+%\documentclass[letterpaper,currency=dollar]{dapper-invoice}
+%\documentclass[letterpaper,currency=euro]{dapper-invoice}
+%\documentclass[letterpaper,currency=pound]{dapper-invoice}
 
 \def\invoiceNo{101}
 \def\balance{137.50}
@@ -27,7 +30,7 @@
         \infoSub{\faMobilePhone}{\small\slshape +1~(555)~555-5555}
         \noalign{\addvspace{8ex}}
         \infoBox{}{
-            {\large\raisebox{.55\height}\$\huge\formatdollars{\balance} \arrowbase} \\
+            {\large\raisebox{.55\height}\currencysym\huge\formatdollars{\balance} \arrowbase} \\
             {\small\color{subduedColor} due \duedate{\duein}}
         }
     \end{infoSection}
@@ -60,10 +63,10 @@
 
     \beginsummary
 
-    \summaryline{Total}{\$\formatdollars{\InvoiceTotal}}
+    \summaryline{Total}{\currencysym\formatdollars{\InvoiceTotal}}
 
-    \summaryline{Paid}{\$\formatdollars{50}}
-    \summaryline{Balance Due}{\$\formatdollars{\balance}} % not really any math support (yet)
+    \summaryline{Paid}{\currencysym\formatdollars{50}}
+    \summaryline{Balance Due}{\currencysym\formatdollars{\balance}} % not really any math support (yet)
 
 \end{hoursItemizationWithProject}
 


### PR DESCRIPTION
These commits implement handling three major currencies used worldwide (dollar, euro, and pound) for use within invoices.  This allows the dapper-invoice documentclass to have a wider audience and to make it easier for people writing invoices for overseas countries to easily change the currency symbol used within the document.  This PR is submitted in the hope that it is useful; any comments and/or questions are more than welcome!