### PR TITLE
Rename formatdollars to formatcurrency

### DIFF
--- a/dapper-invoice.cls
+++ b/dapper-invoice.cls
@@ -168,7 +168,7 @@
 
 \newcommand*{\calcamount}[2]{%
     \FPmul\t{#1}{#2}%
-    \formatdollars{\t}%
+    \formatcurrency{\t}%
 %
     \FPadd\gt{\InvoiceTotal}{\t}%
     \global\let\InvoiceTotal\gt%
@@ -245,7 +245,7 @@
     }
 }
 
-\newcommand*{\formatdollars}[1]{%
+\newcommand*{\formatcurrency}[1]{%
     \num[group-separator={,}, group-minimum-digits=3, round-mode=places, round-precision=2]{#1}%
 }
 

--- a/example.tex
+++ b/example.tex
@@ -27,7 +27,7 @@
         \infoSub{\faMobilePhone}{\small\slshape +1~(555)~555-5555}
         \noalign{\addvspace{8ex}}
         \infoBox{}{
-            {\large\raisebox{.55\height}\$\huge\formatdollars{\balance} \arrowbase} \\
+            {\large\raisebox{.55\height}\$\huge\formatcurrency{\balance} \arrowbase} \\
             {\small\color{subduedColor} due \duedate{\duein}}
         }
     \end{infoSection}
@@ -60,10 +60,10 @@
 
     \beginsummary
 
-    \summaryline{Total}{\$\formatdollars{\InvoiceTotal}}
+    \summaryline{Total}{\$\formatcurrency{\InvoiceTotal}}
 
-    \summaryline{Paid}{\$\formatdollars{50}}
-    \summaryline{Balance Due}{\$\formatdollars{\balance}} % not really any math support (yet)
+    \summaryline{Paid}{\$\formatcurrency{50}}
+    \summaryline{Balance Due}{\$\formatcurrency{\balance}} % not really any math support (yet)
 
 \end{hoursItemizationWithProject}
 


### PR DESCRIPTION
This is a more general term and thus allows (conceptually, at least) other
currencies to be used within dapper-invoice.