### PR TITLE
Replace \def with \newcommand

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -1,11 +1,11 @@
 \documentclass[letterpaper]{dapper-invoice}
 
-\def\invoiceNo{101}
-\def\balance{137.50}
-\def\duein{15}% days
+\newcommand{\invoiceNo}{101}
+\newcommand{\balance}{137.50}
+\newcommand{\duein}{15}% days
 
-\def\me{Your~Name}
-\def\clientName{Sample~Client}
+\newcommand{\me}{Your~Name}
+\newcommand{\clientName}{Sample~Client}
 
 \setmetadata{\me}{Your Biz}{\invoiceNo}{\clientName}
 


### PR DESCRIPTION
The TeX `\def` command is better written in LaTeX as `\newcommand`.  At least,
this is what the advice about best practices say...