### PR TITLE
Added lmodern to Vagrantfile since this is needed for the fonts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,5 +11,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provision "shell", inline: \
-    'apt-get install -y texlive texlive-fonts-extra texlive-latex-extra texlive-science texlive-xetex'
+    'apt-get install -y texlive texlive-fonts-extra texlive-latex-extra texlive-science texlive-xetex lmodern'
 end


### PR DESCRIPTION
Ubuntu's texlive package doesn't contain the fonts necessary to build the pdf without errors. Installing lmodern fixes this issues and I've updated Vagrantfile to reflect this.